### PR TITLE
Exposed the `Oracle` class/constructor

### DIFF
--- a/lib/oracle.js
+++ b/lib/oracle.js
@@ -39,6 +39,8 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
 
 };
 
+exports.Oracle = Oracle;
+
 /**
  * Oracle connector constructor
  *

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-connector-oracle",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Loopback Oracle Connector",
   "keywords": [ "StrongLoop", "LoopBack", "Oracle", "DataSource", "Connector" ],
   "main": "index.js",


### PR DESCRIPTION
I was tasked with instrumenting the connector's performance. Before this change, it was not possible, since the `Oracle` class was incapsulated inside the `oracle.js` file. Maybe we might also want to check with @ShubhraKar.
