### PR TITLE
Allow use TNS compiled string for connection

### DIFF
--- a/lib/oracle.js
+++ b/lib/oracle.js
@@ -33,6 +33,9 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
         timeout: s.timeout || 10
         
     };
+    if (s.tns) {
+        oracle_settings.tns = s.tns;
+    }
     
     dataSource.connector = new Oracle(oracle, oracle_settings);
     dataSource.connector.dataSource = dataSource;


### PR DESCRIPTION
This simple path will give ability to make connections like this:

```
"oracle": {
    "connector": "oracle",
    "tns" : "(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=xxx.xxx.xxx.xxx)(PORT=1521))(CONNECT_DATA=(SERVER=DEDICATED)(SID=MYDATABASE)))",
    "username": "user",
    "password": "pass"
  }
```

because with current code you can't create connection with SID like (SID=MYDATABASE)
