### PR TITLE
Move the test command from run-tests to package.json test script for generating test result

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "main": "index.js",
   "scripts": {
-    "test": "./run-tests"
+    "test": "./run-tests && ./node_modules/.bin/mocha -R spec --timeout 12000 --require ./test/init/init.js"
   },
   "dependencies": {
     "async": "^0.9.0",

--- a/run-tests
+++ b/run-tests
@@ -10,7 +10,7 @@ else
 fi
 if [ -z "$*" ]; then
   export UV_THREADPOOL_SIZE=64
-  $ROOT/node_modules/.bin/mocha -R spec --timeout 120000 --require $ROOT/test/init/init.js
+  #$ROOT/node_modules/.bin/mocha -R spec --timeout 120000 --require $ROOT/test/init/init.js
 else
   echo "Running provided test command: $*"
   $*


### PR DESCRIPTION
In order to generate the test result xunit.xml, we need to invoke the mocha test command directly in the test script in package.json.
