### PR TITLE
Handle connect error in datasource-juggler instead of connector

### DIFF
--- a/lib/oracle.js
+++ b/lib/oracle.js
@@ -131,11 +131,8 @@ Oracle.prototype.connect = function (callback) {
         self.debug('Connected to ' + self.settings.hostname);
         self.debug('Connection pool ', self.pool.getInfo());
       }
-      callback && callback(err, pool);
-    } else {
-      console.error(err);
-      throw err;
-    }
+    }; 
+    callback && callback(err, pool);
   });
 };
 

--- a/test/oracle.test.js
+++ b/test/oracle.test.js
@@ -161,13 +161,14 @@ describe('lazyConnect', function() {
     var ds = getDS(dsConfig);
 
     ds.on('error', function(err) {
-      err.message.should.containEql('ECONNREFUSED');
+      err.message.should.containEql('TNS');
       done();
     });
   });
+
+  var getDS = function(config) {
+    var db = new CreateDS(require('../'), config);
+    return db;
+  };
 });
 
-getDS = function(config) {
-  var db = new CreateDS(require('../'), config);
-  return db;
-};


### PR DESCRIPTION
Don't throw connection error in connector:
https://github.com/strongloop/loopback-connector-oracle/blob/master/lib/oracle.js#L137

> make sure the err is reported via callback.