### PR TITLE
Allow oracledb settings to be honored at pool/execution levels

### DIFF
--- a/lib/oracle.js
+++ b/lib/oracle.js
@@ -30,6 +30,28 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
   }
 
   var s = dataSource.settings || {};
+
+  var configProperties = {
+    autoCommit: true,
+    connectionClass: 'loopback-connector-oracle',
+    extendedMetaData: undefined,
+    externalAuth: undefined,
+    fetchAsString: undefined,
+    lobPrefetchSize: undefined,
+    maxRows: undefined,
+    outFormat: oracle.OBJECT,
+    poolIncrement: undefined,
+    poolMax: undefined,
+    poolMin: undefined,
+    poolPingInterval: undefined,
+    poolTimeout: undefined,
+    prefetchRows: undefined,
+    Promise: undefined,
+    queueRequests: undefined,
+    queueTimeout: undefined,
+    stmtCacheSize: undefined,
+  };
+
   var oracleSettings = {
     connectString: s.connectString || s.url || s.tns,
     user: s.username || s.user,
@@ -39,15 +61,15 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
     poolMax: s.poolMax || s.maxConn || 10,
     poolIncrement: s.poolIncrement || s.incrConn || 1,
     poolTimeout: s.poolTimeout || s.timeout || 60,
-    isAutoCommit: s.isAutoCommit || s.autoCommit,
+    autoCommit: s.autoCommit || s.isAutoCommit,
     outFormat: oracle.OBJECT,
     maxRows: s.maxRows || 100,
     stmtCacheSize: s.stmtCacheSize || 30,
     connectionClass: 'loopback-connector-oracle',
   };
 
-  if (oracleSettings.isAutoCommit === undefined) {
-    oracleSettings.isAutoCommit = true; // Default to true
+  if (oracleSettings.autoCommit === undefined) {
+    oracleSettings.autoCommit = true; // Default to true
   }
 
   if (!oracleSettings.connectString) {
@@ -58,13 +80,11 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
       '/' + database;
   }
 
-  /*
   for (var p in s) {
-    if (!(p in oracleSettings)) {
+    if (!(p in oracleSettings) && p in configProperties) {
       oracleSettings[p] = s[p];
     }
   }
-  */
 
   dataSource.connector = new Oracle(oracle, oracleSettings);
   dataSource.connector.dataSource = dataSource;
@@ -104,6 +124,14 @@ function Oracle(oracle, settings) {
   if (settings.debug || debug.enabled) {
     debug('Settings: %j', settings);
   }
+  this.exectuteOptions = {
+    autoCommit: settings.autoCommit,
+    fetchAsString: settings.fetchAsString,
+    lobPrefetchSize: settings.lobPrefetchSize,
+    maxRows: settings.maxRows,
+    outFormat: oracle.OBJECT,
+    prefetchRows: settings.prefetchRows,
+  };
 }
 
 // Inherit from loopback-datasource-juggler BaseSQL
@@ -186,12 +214,17 @@ Oracle.prototype.executeSQL = function(sql, params, options, callback) {
     }
   }
 
+  var executeOptions = {};
+  for (var i in this.exectuteOptions) {
+    executeOptions[i] = this.exectuteOptions[i];
+  }
   var transaction = options.transaction;
   if (transaction && transaction.connection &&
     transaction.connector === this) {
     debug('Execute SQL within a transaction');
-    transaction.connection.execute(sql, params,
-      {outFormat: oracle.OBJECT, autoCommit: false}, function(err, data) {
+    executeOptions.autoCommit = false;
+    transaction.connection.execute(sql, params, executeOptions,
+      function(err, data) {
         if (err && self.settings.debug) {
           self.debug(err);
         }
@@ -218,8 +251,9 @@ Oracle.prototype.executeSQL = function(sql, params, options, callback) {
     connection.module = self.settings.module || 'loopback-connector-oracle';
     connection.action = self.settings.action || '';
 
+    executeOptions.autoCommit = true;
     connection.execute(sql, params,
-      {outFormat: oracle.OBJECT, autoCommit: true},
+      executeOptions,
       function(err, data) {
         if (err && self.settings.debug) {
           self.debug(err);


### PR DESCRIPTION
### Description

Some of the oracledb settings cannot be configured at pool level. This PR allows such use cases.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
