### PR TITLE
Use fetchAsString for CLOB

### DIFF
--- a/lib/oracle.js
+++ b/lib/oracle.js
@@ -124,9 +124,12 @@ function Oracle(oracle, settings) {
   if (settings.debug || debug.enabled) {
     debug('Settings: %j', settings);
   }
-  this.exectuteOptions = {
+  oracle.fetchAsString = settings.fetchAsString || [oracle.CLOB];
+  oracle.fetchAsBuffer = settings.fetchAsBuffer || [oracle.BLOB];
+  this.executeOptions = {
     autoCommit: settings.autoCommit,
-    fetchAsString: settings.fetchAsString,
+    fetchAsString: settings.fetchAsString || [oracle.CLOB],
+    fetchAsBuffer: settings.fetchAsBuffer || [oracle.BLOB],
     lobPrefetchSize: settings.lobPrefetchSize,
     maxRows: settings.maxRows,
     outFormat: oracle.OBJECT,
@@ -174,28 +177,6 @@ Oracle.prototype.connect = function(callback) {
   });
 };
 
-function readStream(stream, cb) {
-  var data = '';
-  if (stream.type === oracle.CLOB) {
-    stream.setEncoding('utf-8');
-  } else {
-    data = new Buffer();
-  }
-  stream.on('error', function(err) {
-    cb(err);
-  });
-  stream.on('data', function(chunk) {
-    if (stream.type === oracle.CLOB) {
-      data += chunk;
-    } else {
-      data = Buffer.concat(data, chunk);
-    }
-  });
-  stream.on('end', function() {
-    cb(null, data);
-  });
-}
-
 /**
  * Execute the SQL statement.
  *
@@ -215,8 +196,8 @@ Oracle.prototype.executeSQL = function(sql, params, options, callback) {
   }
 
   var executeOptions = {};
-  for (var i in this.exectuteOptions) {
-    executeOptions[i] = this.exectuteOptions[i];
+  for (var i in this.executeOptions) {
+    executeOptions[i] = this.executeOptions[i];
   }
   var transaction = options.transaction;
   if (transaction && transaction.connection &&
@@ -252,8 +233,7 @@ Oracle.prototype.executeSQL = function(sql, params, options, callback) {
     connection.action = self.settings.action || '';
 
     executeOptions.autoCommit = true;
-    connection.execute(sql, params,
-      executeOptions,
+    connection.execute(sql, params, executeOptions,
       function(err, data) {
         if (err && self.settings.debug) {
           self.debug(err);
@@ -266,36 +246,9 @@ Oracle.prototype.executeSQL = function(sql, params, options, callback) {
             if (self.settings.debug && data) {
               self.debug('Result: %j', data);
             }
-            if (Array.isArray(data)) {
-              for (var i = 0, n = data.length; i < n; i++) {
-                // Iterate through the rows
-                var row = data[i];
-                for (var k in row) {
-                  var val = row[k];
-                  if (val instanceof stream.Readable) {
-                    lobs.push({index: i, key: k, stream: val});
-                  }
-                }
-              }
-            }
           }
-          if (lobs.length === 0) {
-            releaseConnectionAndCallback();
-            return;
-          }
-          async.each(lobs, function(lob, done) {
-            readStream(lob.stream, function(err, d) {
-              if (err) return done(err);
-              data[lob.index][lob.key] = d;
-              done();
-            });
-          }, function(err) {
-            if (err) return callback(err);
-            releaseConnectionAndCallback();
-          });
-        } else {
-          releaseConnectionAndCallback();
         }
+        releaseConnectionAndCallback();
 
         function releaseConnectionAndCallback() {
           connection.release(function(err) {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "config": {
     "oracleUrl": "http://7e9918db41dd01dbf98e-ec15952f71452bc0809d79c86f5751b6.r22.cf1.rackcdn.com",
-    "oracleVersion": "2.0.0",
-    "driverModule": "oracledb@^1.12.0"
+    "oracleVersion": "2.1.0",
+    "driverModule": "oracledb@^1.13.0"
   },
   "dependencies": {
     "async": "^2.1.5",


### PR DESCRIPTION
### Description

This PR uses `oracledb.fetchAsString` and `oracledb.fetchAsBuffer` options to simplify CLOB/BLOB reading.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
