### PR TITLE
Add test case for order by random

### DIFF
--- a/lib/oracle.js
+++ b/lib/oracle.js
@@ -626,6 +626,14 @@ Oracle.prototype.ping = function(cb) {
   this.execute('select count(*) as result from user_tables', [], cb);
 };
 
+/**
+ * Build order by random
+ * @returns {string} the order by random() statement
+ */
+Oracle.prototype.buildOrderByRandom = function() {
+  return 'ORDER BY dbms_random.value()';
+};
+
 require('./migration')(Oracle, oracle);
 require('./discovery')(Oracle, oracle);
 require('./transaction')(Oracle, oracle);

--- a/test/oracle.test.js
+++ b/test/oracle.test.js
@@ -50,21 +50,21 @@ describe('oracle connector', function() {
       Post.create({title: 'd', content: 'DDD'}, function(err, post2) {
         Post.create({title: 'e', content: 'EEE'}, function(err, post3) {
           Post.find({order: '${random}'}, function(err, randomPosts1) {
-           should.not.exists(err);
-           var order1 = randomPosts1.map(function(u) { return u.id; });
-           (order1.length).should.eql(randomPosts1.length);
-           order1.should.containEql(1, 2, 3);
-           Post.find( {order: '${random}'}, function(err, randomPosts2) {
-             should.not.exist(err);
-             var order2 = randomPosts2.map(function(u) { return u.id; });
-             (order2.length).should.eql(randomPosts2.length);
-             order2.should.containEql(1, 2, 3);
-               //Though it is a possibility, but probability is very low.
-             should(order1).not.eql(order2);
-             done();
-           });
-         });
-       });
+            should.not.exists(err);
+            var order1 = randomPosts1.map(function(u) { return u.id; });
+            (order1.length).should.eql(randomPosts1.length);
+            order1.should.containEql(1, 2, 3);
+            Post.find({order: '${random}'}, function(err, randomPosts2) {
+              should.not.exist(err);
+              var order2 = randomPosts2.map(function(u) { return u.id; });
+              (order2.length).should.eql(randomPosts2.length);
+              order2.should.containEql(1, 2, 3);
+               // Though it is a possibility, but probability is very low.
+              should(order1).not.eql(order2);
+              done();
+            });
+          });
+        });
       });
     });
   });

--- a/test/oracle.test.js
+++ b/test/oracle.test.js
@@ -49,12 +49,12 @@ describe('oracle connector', function() {
     Post.create({title: 'c', content: 'CCC'}, function(err, post1) {
       Post.create({title: 'd', content: 'DDD'}, function(err, post2) {
         Post.create({title: 'e', content: 'EEE'}, function(err, post3) {
-          Post.find({order: 'rand'}, function(err, randomPosts1) {
+          Post.find({order: '${random}'}, function(err, randomPosts1) {
            should.not.exists(err);
            var order1 = randomPosts1.map(function(u) { return u.id; });
            (order1.length).should.eql(randomPosts1.length);
            order1.should.containEql(1, 2, 3);
-           Post.find( {order: 'rand'}, function(err, randomPosts2) {
+           Post.find( {order: '${random}'}, function(err, randomPosts2) {
              should.not.exist(err);
              var order2 = randomPosts2.map(function(u) { return u.id; });
              (order2.length).should.eql(randomPosts2.length);

--- a/test/oracle.test.js
+++ b/test/oracle.test.js
@@ -45,6 +45,30 @@ describe('oracle connector', function() {
     });
   });
 
+  it('should support order with random sorting', function(done) {
+    Post.create({title: 'c', content: 'CCC'}, function(err, post1) {
+      Post.create({title: 'd', content: 'DDD'}, function(err, post2) {
+        Post.create({title: 'e', content: 'EEE'}, function(err, post3) {
+          Post.find({order: 'rand'}, function(err, randomPosts1) {
+           should.not.exists(err);
+           var order1 = randomPosts1.map(function(u) { return u.id; });
+           (order1.length).should.eql(randomPosts1.length);
+           order1.should.containEql(1, 2, 3);
+           Post.find( {order: 'rand'}, function(err, randomPosts2) {
+             should.not.exist(err);
+             var order2 = randomPosts2.map(function(u) { return u.id; });
+             (order2.length).should.eql(randomPosts2.length);
+             order2.should.containEql(1, 2, 3);
+               //Though it is a possibility, but probability is very low.
+             should(order1).not.eql(order2);
+             done();
+           });
+         });
+       });
+      });
+    });
+  });
+
   it('should support updating boolean types with false value', function(done) {
     Post.update({id: post.id}, {approved: false}, function(err) {
       should.not.exists(err);
@@ -172,4 +196,3 @@ describe('lazyConnect', function() {
     return db;
   };
 });
-


### PR DESCRIPTION
### Description
Add order by rand () for Oracle connector.
tests couldn't be unified in juggler since they are code specific and they work only for 4 connectors. 

#### Related issues

connect to https://github.com/strongloop/loopback/issues/902
To test feature in pr: https://github.com/strongloop/loopback-connector/pull/102
Original PR that cannot be used since the function is completely refactored
https://github.com/strongloop/loopback-connector-mysql/pull/62

### Checklist


- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

