### PR TITLE
Load local init.js first

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha --UV_THREADPOOL_SIZE=100 test/*.js",
+    "test": "mocha --require test/init/init.js --UV_THREADPOOL_SIZE=100 test/*.js",
     "posttest": "npm run lint"
   },
   "config": {


### PR DESCRIPTION
### Description

Make sure the local `./test/init/init.js` get loaded before the `init.js` in juggler, otherwise describe/it if logic will be executed with juggler's connector flag.
