### PR TITLE
Update to MIT license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,8 +1,25 @@
-Licensed Materials - Property of IBM
-IBM StrongLoop Software
-Copyright IBM Corp. 2016. All Rights Reserved.
-US Government Users Restricted Rights - Use, duplication or disclosure
-restricted by GSA ADP Schedule Contract with IBM Corp.
+Copyright (c) IBM Corp. 2012,2018. All Rights Reserved.
+Node module: loopback-connector-oracle
+This project is licensed under the MIT License, full text below.
 
-See full text of IBM International Program License Agreement (IPLA)
-http://www-03.ibm.com/software/sla/sladb.nsf/pdf/ipla/$file/ipla.pdf
+--------
+
+MIT license
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/example/app.js
+++ b/example/app.js
@@ -1,5 +1,8 @@
-// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Copyright IBM Corp. 2013,2018. All Rights Reserved.
 // Node module: loopback-connector-oracle
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // US Government Users Restricted Rights - Use, duplication or disclosure
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 'use strict';

--- a/example/app.js
+++ b/example/app.js
@@ -3,8 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
 'use strict';
 
 var g = require('strong-globalize')();

--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
-// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Copyright IBM Corp. 2013,2018. All Rights Reserved.
 // Node module: loopback-connector-oracle
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // US Government Users Restricted Rights - Use, duplication or disclosure
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 'use strict';

--- a/index.js
+++ b/index.js
@@ -3,8 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
 'use strict';
 var SG = require('strong-globalize');
 SG.SetRootDir(__dirname);

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -3,8 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
 'use strict';
 var g = require('strong-globalize')();
 var async = require('async');

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -1,5 +1,8 @@
-// Copyright IBM Corp. 2015. All Rights Reserved.
+// Copyright IBM Corp. 2015,2018. All Rights Reserved.
 // Node module: loopback-connector-oracle
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // US Government Users Restricted Rights - Use, duplication or disclosure
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 'use strict';

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -3,8 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
 'use strict';
 
 var async = require('async');

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -1,5 +1,8 @@
-// Copyright IBM Corp. 2015. All Rights Reserved.
+// Copyright IBM Corp. 2015,2018. All Rights Reserved.
 // Node module: loopback-connector-oracle
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // US Government Users Restricted Rights - Use, duplication or disclosure
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 'use strict';

--- a/lib/oracle.js
+++ b/lib/oracle.js
@@ -1,5 +1,8 @@
-// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Copyright IBM Corp. 2013,2018. All Rights Reserved.
 // Node module: loopback-connector-oracle
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // US Government Users Restricted Rights - Use, duplication or disclosure
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 'use strict';

--- a/lib/oracle.js
+++ b/lib/oracle.js
@@ -3,8 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
 'use strict';
 
 var g = require('strong-globalize')();

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -1,5 +1,8 @@
-// Copyright IBM Corp. 2015. All Rights Reserved.
+// Copyright IBM Corp. 2015,2018. All Rights Reserved.
 // Node module: loopback-connector-oracle
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // US Government Users Restricted Rights - Use, duplication or disclosure
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -3,9 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
-
 'use strict';
 
 var g = require('strong-globalize')();

--- a/package.json
+++ b/package.json
@@ -38,5 +38,6 @@
     "type": "git",
     "url": "https://github.com/strongloop/loopback-connector-oracle.git"
   },
-  "license": "SEE LICENSE IN LICENSE.md"
+  "copyright.owner": "IBM Corp.",
+  "license": "MIT"
 }

--- a/test/init/init.js
+++ b/test/init/init.js
@@ -3,8 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
 'use strict';
 
 var DataSource = require('loopback-datasource-juggler').DataSource;

--- a/test/init/init.js
+++ b/test/init/init.js
@@ -1,5 +1,8 @@
-// Copyright IBM Corp. 2013,2015. All Rights Reserved.
+// Copyright IBM Corp. 2013,2018. All Rights Reserved.
 // Node module: loopback-connector-oracle
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // US Government Users Restricted Rights - Use, duplication or disclosure
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 'use strict';

--- a/test/oracle.autoupdate.test.js
+++ b/test/oracle.autoupdate.test.js
@@ -1,5 +1,8 @@
-// Copyright IBM Corp. 2013,2015. All Rights Reserved.
+// Copyright IBM Corp. 2013,2018. All Rights Reserved.
 // Node module: loopback-connector-oracle
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // US Government Users Restricted Rights - Use, duplication or disclosure
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 'use strict';

--- a/test/oracle.autoupdate.test.js
+++ b/test/oracle.autoupdate.test.js
@@ -3,8 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
 'use strict';
 
 /* global getDataSource */

--- a/test/oracle.clob.test.js
+++ b/test/oracle.clob.test.js
@@ -3,9 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
-
 'use strict';
 
 /* global getDataSource */

--- a/test/oracle.clob.test.js
+++ b/test/oracle.clob.test.js
@@ -1,5 +1,8 @@
-// Copyright IBM Corp. 2014. All Rights Reserved.
+// Copyright IBM Corp. 2014,2018. All Rights Reserved.
 // Node module: loopback-connector-oracle
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // US Government Users Restricted Rights - Use, duplication or disclosure
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 

--- a/test/oracle.connectionpool.test.js
+++ b/test/oracle.connectionpool.test.js
@@ -1,5 +1,8 @@
-// Copyright IBM Corp. 2013,2015. All Rights Reserved.
+// Copyright IBM Corp. 2013,2018. All Rights Reserved.
 // Node module: loopback-connector-oracle
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // US Government Users Restricted Rights - Use, duplication or disclosure
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 

--- a/test/oracle.connectionpool.test.js
+++ b/test/oracle.connectionpool.test.js
@@ -3,9 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
-
 'use strict';
 
 /* global getDataSource */

--- a/test/oracle.discover.test.js
+++ b/test/oracle.discover.test.js
@@ -1,5 +1,8 @@
-// Copyright IBM Corp. 2013,2015. All Rights Reserved.
+// Copyright IBM Corp. 2013,2018. All Rights Reserved.
 // Node module: loopback-connector-oracle
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // US Government Users Restricted Rights - Use, duplication or disclosure
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 

--- a/test/oracle.discover.test.js
+++ b/test/oracle.discover.test.js
@@ -3,9 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
-
 'use strict';
 
 /* global getDataSource */

--- a/test/oracle.mapping.js
+++ b/test/oracle.mapping.js
@@ -1,5 +1,8 @@
-// Copyright IBM Corp. 2013,2015. All Rights Reserved.
+// Copyright IBM Corp. 2013,2018. All Rights Reserved.
 // Node module: loopback-connector-oracle
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // US Government Users Restricted Rights - Use, duplication or disclosure
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 

--- a/test/oracle.mapping.js
+++ b/test/oracle.mapping.js
@@ -3,9 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
-
 'use strict';
 
 /* global getDataSource */

--- a/test/oracle.regexp.test.js
+++ b/test/oracle.regexp.test.js
@@ -1,5 +1,8 @@
-// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: loopback-connector-oracle
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // US Government Users Restricted Rights - Use, duplication or disclosure
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 

--- a/test/oracle.regexp.test.js
+++ b/test/oracle.regexp.test.js
@@ -3,9 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
-
 'use strict';
 
 /* global getDataSource */

--- a/test/oracle.test.js
+++ b/test/oracle.test.js
@@ -1,5 +1,8 @@
-// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Copyright IBM Corp. 2013,2018. All Rights Reserved.
 // Node module: loopback-connector-oracle
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // US Government Users Restricted Rights - Use, duplication or disclosure
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 

--- a/test/oracle.test.js
+++ b/test/oracle.test.js
@@ -3,9 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
-
 'use strict';
 
 /* global getDataSource */

--- a/test/oracle.transaction.test.js
+++ b/test/oracle.transaction.test.js
@@ -1,5 +1,8 @@
-// Copyright IBM Corp. 2015. All Rights Reserved.
+// Copyright IBM Corp. 2015,2018. All Rights Reserved.
 // Node module: loopback-connector-oracle
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // US Government Users Restricted Rights - Use, duplication or disclosure
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 

--- a/test/oracle.transaction.test.js
+++ b/test/oracle.transaction.test.js
@@ -3,9 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// US Government Users Restricted Rights - Use, duplication or disclosure
-// restricted by GSA ADP Schedule Contract with IBM Corp.
-
 'use strict';
 
 /* global getDataSource */


### PR DESCRIPTION
### Description
To help to continue growing the community, we decided to change the license of this module to MIT license.

The license used here is using https://github.com/strongloop/loopback-connector-mysql/blob/master/LICENSE as reference.

Changes involved in this PR:
- update `LICENSE.md` to MIT license
- update `license` and `copyright.owner` field, in `package.json`
- run `slt copyright` to update the copyright statement in the header of source code files.

Originated from https://github.com/strongloop-internal/scrum-apex/issues/382