### PR TITLE
Added the connection property "_enableStats"

### DIFF
--- a/lib/oracle.js
+++ b/lib/oracle.js
@@ -52,6 +52,7 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
     queueRequests: undefined,
     queueTimeout: undefined,
     stmtCacheSize: undefined,
+    _enableStats: undefined,
   };
 
   var oracleSettings = {
@@ -67,6 +68,7 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
     outFormat: oracle.OBJECT,
     maxRows: s.maxRows || 0,
     stmtCacheSize: s.stmtCacheSize || 30,
+    _enableStats: s._enableStats || false,
     connectionClass: 'loopback-connector-oracle',
   };
 


### PR DESCRIPTION
Added the connection property "_enableStats".

Added the properties "_enableStats" of the oracledb settings in the validation of properties accepted by the connector.

We had problems with our application and we needed to see the connection and connection pool statuses, but it was not possible because the "_enableStats" property was not mapped.