### PR TITLE
Fix CI

### DIFF
--- a/test/oracle.test.js
+++ b/test/oracle.test.js
@@ -6,8 +6,8 @@
 'use strict';
 
 /* global getDataSource */
-var juggler = require('loopback-datasource-juggler');
-var CreateDS = juggler.DataSource;
+const juggler = require('loopback-datasource-juggler');
+const CreateDS = juggler.DataSource;
 
 require('./init/init');
 const should = require('should');


### PR DESCRIPTION
Addresses CI failure reported in https://github.com/strongloop/loopback-connector-oracle/issues/183.

`var` had to be changed to `const` to fix linting error.