### PR TITLE
Allow CLOB/BLOB data types for migration

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -405,6 +405,9 @@ function mixinMigration(Oracle) {
     const colLength = columnMetadata && columnMetadata.dataLength ||
                       prop.length;
     if (colType) {
+      if (colType === 'CLOB' || colType === 'BLOB') {
+        return colType;
+      }
       return colType + (colLength ? '(' + colLength + ')' : '');
     }
 


### PR DESCRIPTION
There's currently no way to create a CLOB data type. I would expect that `type` of "Object" or "JSON" would default to CLOB since Oracle varchar2's are only 4,000 characters by default in STANDARD mode. At this point, changing the code would break things, so this PR is a "no-brainer" that couldn't possibly break anything. Basically you would just set columnMetadata for Oracle, like this:

```
"props": {
  "type": "object",
  "required": false,
  "length": "MAX",
  "oracle": {
    "dataType": "CLOB" 
  }
},
```

The main problem with the current code is that CLOB's have no defined dataLength, but props.length needs to be defined for other databases, this [this line](https://github.com/strongloop/loopback-connector-oracle/blob/master/lib/migration.js#L408) is a problem and thus requires this PR.
