### PR TITLE
Table columns in proper order

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -204,6 +204,7 @@ function mixinDiscovery(Oracle) {
         (table ? ' WHERE table_name=\'' + table + '\'' : ''), +
       'table_name, column_id', {});
     }
+    sql += ' ORDER BY column_id';
     return sql;
   };
 


### PR DESCRIPTION
Without `ORDER BY column_id`, columns may not be in proper order when returned from the `buildQueryColumns` function.